### PR TITLE
feat(blog): add getArticleBySlug and generateStaticParams

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -43,11 +43,7 @@
         "noUselessElse": "error"
       }
     },
-    "includes": [
-      "src/**/*",
-      "!src/components/ui/**/*",
-      "!**/src/app/providers.tsx"
-    ]
+    "includes": ["src/**/*", "!src/components/ui/**/*"]
   },
   "javascript": {
     "formatter": {

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,6 @@
         "posthog-js": "1.347.2",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "sugar-high": "0.9.5",
         "tailwind-merge": "3.4.1",
         "tailwindcss-animate": "1.0.7",
       },
@@ -32,6 +31,7 @@
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "postcss": "8.5.6",
+        "shiki": "^3.22.0",
         "tailwindcss": "4.1.18",
         "typescript": "5.9.3",
       },
@@ -208,6 +208,20 @@
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
 
+    "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-jdKhfgW9CRtj3Tor0L7+yPwdG3CgP7W+ZEqSsojrMzCjD1e0IxIbwUMDDpYlVBlC08TACg4puwFGkZfLS+56Tw=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA=="],
+
+    "@shikijs/langs": ["@shikijs/langs@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0" } }, "sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA=="],
+
+    "@shikijs/themes": ["@shikijs/themes@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0" } }, "sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g=="],
+
+    "@shikijs/types": ["@shikijs/types@3.22.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@stripe/react-stripe-js": ["@stripe/react-stripe-js@3.10.0", "", { "dependencies": { "prop-types": "^15.7.2" }, "peerDependencies": { "@stripe/stripe-js": ">=1.44.1 <8.0.0", "react": ">=16.8.0 <20.0.0", "react-dom": ">=16.8.0 <20.0.0" } }, "sha512-UPqHZwMwDzGSax0ZI7XlxR3tZSpgIiZdk3CiwjbTK978phwR/fFXeAXQcN/h8wTAjR4ZIAzdlI9DbOqJhuJdeg=="],
 
     "@stripe/stripe-js": ["@stripe/stripe-js@5.10.0", "", {}, "sha512-PTigkxMdMUP6B5ISS7jMqJAKhgrhZwjprDqR1eATtFfh0OpKVNp110xiH+goeVdrJ29/4LeZJR4FaHHWstsu0A=="],
@@ -348,9 +362,13 @@
 
     "hast-util-to-estree": ["hast-util-to-estree@3.1.3", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-attach-comments": "^3.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w=="],
 
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
@@ -492,6 +510,10 @@
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
+    "oniguruma-parser": ["oniguruma-parser@0.12.1", "", {}, "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.4", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA=="],
+
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -526,6 +548,12 @@
 
     "recma-stringify": ["recma-stringify@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-to-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g=="],
 
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
     "rehype-recma": ["rehype-recma@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "hast-util-to-estree": "^3.0.0" } }, "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw=="],
 
     "remark-mdx": ["remark-mdx@3.1.1", "", { "dependencies": { "mdast-util-mdx": "^3.0.0", "micromark-extension-mdxjs": "^3.0.0" } }, "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg=="],
@@ -544,6 +572,8 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "shiki": ["shiki@3.22.0", "", { "dependencies": { "@shikijs/core": "3.22.0", "@shikijs/engine-javascript": "3.22.0", "@shikijs/engine-oniguruma": "3.22.0", "@shikijs/langs": "3.22.0", "@shikijs/themes": "3.22.0", "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g=="],
+
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
@@ -557,8 +587,6 @@
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
-
-    "sugar-high": ["sugar-high@0.9.5", "", {}, "sha512-eirwp9p7QcMg6EFCD6zrGh4H30uFx2YtfiMJUavagceP6/YUUjLeiQmis7QuwqKB3nXrWXlLaRumCqOd9AKpSA=="],
 
     "tailwind-merge": ["tailwind-merge@3.4.1", "", {}, "sha512-2OA0rFqWOkITEAOFWSBSApYkDeH9t2B3XSJuI4YztKBzK3mX0737A2qtxDZ7xkw9Zfh0bWl+r34sF3HXV+Ig7Q=="],
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "posthog-js": "1.347.2",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "sugar-high": "0.9.5",
     "tailwind-merge": "3.4.1",
     "tailwindcss-animate": "1.0.7"
   },
@@ -39,6 +38,7 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "postcss": "8.5.6",
+    "shiki": "^3.22.0",
     "tailwindcss": "4.1.18",
     "typescript": "5.9.3"
   }

--- a/src/app/(blogs)/blogs/2020-03-03_Mongodb-REPLICATION-505c2b71a360.mdx
+++ b/src/app/(blogs)/blogs/2020-03-03_Mongodb-REPLICATION-505c2b71a360.mdx
@@ -193,7 +193,7 @@ docker-compose exec demo-mongo-primary mongo -u "root" -p "password"
 
 8. Instatiate the replica set
 
-```terminal
+```text
 rs.initiate(
     {"_id" : "tut12-replica-set",
     "members" : [
@@ -207,7 +207,7 @@ rs.initiate(
 
 9. Set the priority of the master over the other nodes
 
-```terminal
+```text
 conf = rs.config();
 conf.members[0].priority = 2;
 rs.reconfig(conf);

--- a/src/app/(blogs)/blogs/2020-03-13_Minimizing-python-docker-images-cf99f4468d39.mdx
+++ b/src/app/(blogs)/blogs/2020-03-13_Minimizing-python-docker-images-cf99f4468d39.mdx
@@ -73,7 +73,7 @@ it and the allocated resources.
 
 Lets create a python Flask app for demonstration purposes:
 
-```python3
+```python
 from flask import Flask
 
 app = Flask(__name__)
@@ -124,7 +124,7 @@ Werkzeug==1.0.0
 
 We write a first Dockerfile:
 
-```Dockerfile
+```dockerfile
 FROM ubuntu
 LABEL Maintainer="Rodney Osodo"
 WORKDIR /app
@@ -149,7 +149,7 @@ Our docker images size is 1.28GB, which isn't that bad but is extremely bad.
 
 Lets make another dockerfile from python as the base image:
 
-```Dockerfile
+```dockerfile
 FROM python
 WORKDIR /app
 COPY . .
@@ -184,7 +184,7 @@ Use alpine as base when you care about image size.
 
 Lets try reducing the images. Ahh we should all be happy now, right?
 
-```Dockerfile
+```dockerfile
 FROM python:3.7-slim
 WORKDIR /app
 COPY . .
@@ -194,7 +194,7 @@ CMD ["python", "app.py"]
 
 Image size is 209MB
 
-```Dockerfile
+```dockerfile
 FROM python:3.7-slim-stretch
 WORKDIR /app
 COPY . .
@@ -207,7 +207,7 @@ Image size is 186MB
 Definitely slim-stretch is better than slim.
 What about our alpine base image?
 
-```Dockerfile
+```dockerfile
 FROM python:3.7-alpine
 WORKDIR /app
 COPY . .
@@ -231,7 +231,7 @@ files. When copying use dockerignore to exclude files that are not needed.
     - pip3 — no-cache-dir
     - apk — no-cache
 
-```Dockerfile
+```dockerfile
 FROM python:3.7-alpine
 WORKDIR /app
 COPY . .
@@ -246,7 +246,7 @@ Size 107MB
 - Build a docker image with all your deps then install your app.
 - Copy the result to a fresh image and label is as the final image.
 
-```Dockerfile
+```dockerfile
 # Stage 1 - Install build dependencies
 FROM python:3.7-alpine AS builder
 WORKDIR /app
@@ -292,7 +292,7 @@ func main() {
 We compile the program then it will generated an executable file which we can
 ran from a scratch image:
 
-```Dockerfile
+```dockerfile
 FROM scratch
 COPY app /
 CMD ["/app"]

--- a/src/app/(blogs)/blogs/2021-01-21_Qa1--My-Quantum-Open-Source-Foundation-Project-402d4f1df1a5.mdx
+++ b/src/app/(blogs)/blogs/2021-01-21_Qa1--My-Quantum-Open-Source-Foundation-Project-402d4f1df1a5.mdx
@@ -75,7 +75,7 @@ explanations of the each column is as follows:
 print(data.columns)
 ```
 
-```terminal
+```text
 Index(['age', 'sex', 'cp', 'trestbps', 'chol', 'fbs', 'restecg', 'thalach', 'exang', 'oldpeak', 'slope', 'ca', 'thal', 'num       '], dtype='object')
 ```
 

--- a/src/app/(blogs)/blogs/2021-01-23_Q1c--An-analysis-of-the-variational-quantum-classifier-using-data-5cd29be55a58.mdx
+++ b/src/app/(blogs)/blogs/2021-01-23_Q1c--An-analysis-of-the-variational-quantum-classifier-using-data-5cd29be55a58.mdx
@@ -259,7 +259,7 @@ typically performs better in general?
 
 **Iris dataset**
 
-```terminal
+```text
 PauliFeatureMap(4, reps=4) SPSA(max_trials=50) vdepth 3 : Cost: 0.18055905629600544
 ZZFeatureMap(4, reps=2) SPSA(max_trials=50) vdepth 5 : Cost: 0.18949957468013437
 ZFeatureMap(4, reps=2) SPSA(max_trials=50) vdepth 5 : Cost: 0.18975231416858743
@@ -274,7 +274,7 @@ ZFeatureMap(4, reps=4) SPSA(max_trials=50) vdepth 3 : Cost: 0.19970277845347006
 
 **Wine dataset**
 
-```terminal
+```text
 PauliFeatureMap(4, reps=1) SPSA(max_trials=50) vdepth 5 : Cost: 0.1958180042610037
 PauliFeatureMap(4, reps=1) SPSA(max_trials=50) vdepth 3 : Cost: 0.1962278498243972
 PauliFeatureMap(4, reps=2) SPSA(max_trials=50) vdepth 3 : Cost: 0.20178754496022344

--- a/src/app/(blogs)/blogs/2021-10-15_H2--IoT-hardware-for-a-12-factor-application-48b6d16eff17.mdx
+++ b/src/app/(blogs)/blogs/2021-10-15_H2--IoT-hardware-for-a-12-factor-application-48b6d16eff17.mdx
@@ -31,7 +31,7 @@ temperature and humidity sensor. With this, we can send temperature and
 humidity data to our backend services for monitoring purposes.
 
 <blockquote class="twitter-tweet">
-  <p lang="en" dir="ltr">
+  <span lang="en" dir="ltr">
     From design to getting it in the hands of developers. @jkuat_ses we are
     proud to introduce our dev board. Thank you{" "}
     <a href="https://twitter.com/JLCPCB?ref_src=twsrc%5Etfw">@JLCPCB</a> and the
@@ -42,7 +42,8 @@ humidity data to our backend services for monitoring purposes.
   <a href="https://twitter.com/b1ackd0t/status/1406172772221566982?ref_src=twsrc%5Etfw">
     June 19, 2021
   </a>
-</blockquote> <script
+</blockquote>
+<script
   async
   src="https://platform.twitter.com/widgets.js"
   charset="utf-8"

--- a/src/app/(blogs)/blogs/2021-10-18_H4--Second-half-of-the-12-factor-app-b77b0fde6279.mdx
+++ b/src/app/(blogs)/blogs/2021-10-18_H4--Second-half-of-the-12-factor-app-b77b0fde6279.mdx
@@ -42,7 +42,7 @@ they want to config the WIFI username and passwords or if they want to manually
 upgrade or downgrade the application version running in their device. This is
 done by the following.
 
-```app
+```text
 WebServer server(80);
 ```
 

--- a/src/app/(blogs)/blogs/[slug]/page.tsx
+++ b/src/app/(blogs)/blogs/[slug]/page.tsx
@@ -1,14 +1,18 @@
 import { notFound } from "next/navigation";
 import Form from "@/components/form";
 import { CustomMdx } from "@/components/mdx";
-import { getArticles } from "@/lib/blogs";
+import { getArticleBySlug, getArticles } from "@/lib/blogs";
+
+export async function generateStaticParams() {
+  const posts = getArticles();
+  return posts.map((post) => ({ slug: post.slug }));
+}
 
 export default async function Article(props: {
   params: Promise<{ slug: string }>;
 }) {
   const params = await props.params;
-  const posts = getArticles();
-  const post = posts.find((post) => post.slug === params.slug);
+  const post = getArticleBySlug(params.slug);
 
   if (!post) {
     notFound();

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -115,15 +115,6 @@
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
     --radius: 0.5rem;
-
-    --sh-class: #7aa2f7;
-    --sh-sign: #89ddff;
-    --sh-string: #9ece6a;
-    --sh-keyword: #bb9af7;
-    --sh-comment: #565f89;
-    --sh-jsxliterals: #7aa2f7;
-    --sh-property: #73daca;
-    --sh-entity: #e0af68;
   }
   .dark {
     --background: 0 0% 3.9%;
@@ -162,49 +153,25 @@
   }
 }
 
+/* Shiki dual-theme: use light tokens by default, dark tokens in .dark */
+.shiki,
+.shiki span {
+  color: var(--shiki-light);
+  background-color: var(--shiki-light-bg);
+}
+
+.dark .shiki,
+.dark .shiki span {
+  color: var(--shiki-dark);
+  background-color: var(--shiki-dark-bg);
+}
+
 pre {
-  background-color: #16161e;
-  border-radius: 0.5rem;
+  font-family: "Menlo", "Monaco", "Courier New", monospace;
   overflow-x: auto;
-  padding: 1rem;
-  margin: 1.5rem 0;
-  line-height: 1;
+  scrollbar-width: thin;
 }
 
 pre::-webkit-scrollbar {
   display: none;
-}
-
-pre {
-  -ms-overflow-style: none;
-  scrollbar-width: thin;
-}
-
-code {
-  font-family: "Menlo", "Monaco", "Courier New", monospace;
-  font-size: 14px;
-  padding: 0.2em 0.4em;
-  border-radius: 0.3em;
-  background-color: var(--color-gray-100);
-}
-
-pre code {
-  background-color: transparent;
-  padding: 0;
-  border: none;
-  font-size: 14px;
-  line-height: 1.5;
-}
-
-pre code > span .sh__token--identifier {
-  color: white;
-}
-
-pre code span {
-  font-weight: 500;
-}
-
-code:not(pre code) span {
-  font-weight: 500;
-  color: black;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,9 @@ const robotoMono = Roboto_Mono({
   display: "swap",
 });
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://rodneyosodo.com";
+const baseUrl = (
+  process.env.NEXT_PUBLIC_BASE_URL || "https://rodneyosodo.com"
+).replace(/\/+$/, "");
 
 export const metadata: Metadata = {
   metadataBase: new URL(baseUrl),

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -8,12 +8,16 @@ import SuspendedPostHogPageView from "@/app/posthog-page-view";
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
-    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY as string, {
-      api_host: "/ingest",
-      ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST as string,
-      capture_pageview: false,
-      capture_pageleave: true,
-    });
+    const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    const host = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+    if (key && host) {
+      posthog.init(key, {
+        api_host: "/ingest",
+        ui_host: host,
+        capture_pageview: false,
+        capture_pageleave: true,
+      });
+    }
   }, []);
 
   return (

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,8 @@
 import type { MetadataRoute } from "next";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://rodneyosodo.com";
+const baseUrl = (
+  process.env.NEXT_PUBLIC_BASE_URL || "https://rodneyosodo.com"
+).replace(/\/+$/, "");
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,11 +1,13 @@
 import type { MetadataRoute } from "next";
 
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://rodneyosodo.com";
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: "*",
       allow: "/",
     },
-    sitemap: "https://rodneyosodo.com/sitemap.xml",
+    sitemap: `${baseUrl}/sitemap.xml`,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,13 +1,15 @@
 import type { MetadataRoute } from "next";
 import { getArticles } from "@/lib/blogs";
 
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://rodneyosodo.com";
+
 function generateBlogsSitemap() {
   const posts = getArticles();
   const sitemap: MetadataRoute.Sitemap = [];
 
   for (const post of posts) {
     sitemap.push({
-      url: `/blogs/${post.slug}`,
+      url: `${baseUrl}/blogs/${post.slug}`,
       lastModified: new Date(post.metadata.date).toISOString(),
       priority: 0.5,
     });
@@ -19,27 +21,27 @@ function generateBlogsSitemap() {
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: "/",
+      url: `${baseUrl}/`,
       lastModified: new Date().toISOString(),
       priority: 1,
     },
     {
-      url: "/publications",
+      url: `${baseUrl}/publications`,
       lastModified: new Date().toISOString(),
       priority: 0.8,
     },
     {
-      url: "/awards",
+      url: `${baseUrl}/awards`,
       lastModified: new Date().toISOString(),
       priority: 0.7,
     },
     {
-      url: "/talks",
+      url: `${baseUrl}/talks`,
       lastModified: new Date().toISOString(),
       priority: 0.6,
     },
     {
-      url: "/blogs",
+      url: `${baseUrl}/blogs`,
       lastModified: new Date().toISOString(),
       priority: 0.5,
     },

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,9 @@
 import type { MetadataRoute } from "next";
 import { getArticles } from "@/lib/blogs";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://rodneyosodo.com";
+const baseUrl = (
+  process.env.NEXT_PUBLIC_BASE_URL || "https://rodneyosodo.com"
+).replace(/\/+$/, "");
 
 function generateBlogsSitemap() {
   const posts = getArticles();

--- a/src/components/copy-button.tsx
+++ b/src/components/copy-button.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+export function CopyButton({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(code).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <Button
+      size="sm"
+      variant="ghost"
+      className="absolute right-2 top-2 size-7 p-0 opacity-0 transition-opacity group-hover:opacity-100"
+      onClick={handleCopy}
+      aria-label="Copy code"
+    >
+      {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+    </Button>
+  );
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -5,7 +5,7 @@ import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 
 export function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
 
   return (
     <div>
@@ -14,7 +14,7 @@ export function ThemeToggle() {
         size="sm"
         className="size-8 px-0"
         onClick={() => {
-          if (theme === "light") {
+          if (resolvedTheme === "light") {
             setTheme("dark");
           } else {
             setTheme("light");

--- a/src/lib/blogs.ts
+++ b/src/lib/blogs.ts
@@ -57,3 +57,13 @@ function getMdxData(dir: string) {
 export function getArticles() {
   return getMdxData(path.join(process.cwd(), "src", "app", "(blogs)", "blogs"));
 }
+
+export function getArticleBySlug(slug: string) {
+  const dir = path.join(process.cwd(), "src", "app", "(blogs)", "blogs");
+  const filePath = path.join(dir, `${slug}.mdx`);
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  const { metadata, content } = readMdxFile(filePath);
+  return { metadata, slug, content };
+}

--- a/src/lib/blogs.ts
+++ b/src/lib/blogs.ts
@@ -61,6 +61,10 @@ export function getArticles() {
 export function getArticleBySlug(slug: string) {
   const dir = path.join(process.cwd(), "src", "app", "(blogs)", "blogs");
   const filePath = path.join(dir, `${slug}.mdx`);
+  // Ensure the resolved path is within the blogs directory
+  if (!filePath.startsWith(dir)) {
+    return null;
+  }
   if (!fs.existsSync(filePath)) {
     return null;
   }


### PR DESCRIPTION
## Summary by Sourcery

Add slug-based blog article lookup and static path generation while improving robustness of markdown rendering, analytics initialization, and site metadata.

New Features:
- Introduce getArticleBySlug helper to load individual blog posts directly by slug.
- Add generateStaticParams for blog article pages to enable static generation of slug routes.

Enhancements:
- Improve heading ID generation in markdown by deriving slugs from full nested child text content.
- Make code block highlighting resilient to non-string children in markdown components.
- Guard PostHog initialization behind presence of required environment variables to avoid runtime issues.
- Use environment-based base URL when generating sitemap and robots metadata for better configurability.
- Use resolvedTheme from next-themes in the theme toggle for more accurate theme detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clickable heading anchors for improved navigation.
  * Blog routes support static pre-generation for faster loads and SEO.
  * Copy-to-clipboard button for code blocks.
  * Improved code block rendering and theming for consistent light/dark presentation.

* **Bug Fixes**
  * Theme toggle correctly reflects the active theme.

* **Chores**
  * Analytics initialization and base URL handling made more robust.
* **Chores**
  * Sitemap entries now use the configured site URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->